### PR TITLE
Allow query parser to be optionally set to dismax

### DIFF
--- a/sunspot/lib/sunspot/version.rb
+++ b/sunspot/lib/sunspot/version.rb
@@ -1,3 +1,3 @@
 module Sunspot
-  VERSION = '2.2.5'
+  VERSION = '2.2.6'
 end

--- a/sunspot_rails/lib/sunspot/rails/configuration.rb
+++ b/sunspot_rails/lib/sunspot/rails/configuration.rb
@@ -331,6 +331,14 @@ module Sunspot #:nodoc:
           (user_configuration_from_key('auto_remove_callback') || 'after_destroy')
       end
 
+      #
+      # The query parser that should be used (useful for legacy systems).
+      # Default 'edismax'.
+      #
+      def query_parser
+        @query_parser ||= (user_configuration_from_key('query_parser') || 'edismax')
+      end
+
       private
 
       #


### PR DESCRIPTION
This commit adds the option to set the query parser to dismax via a
user_configuration variable `query_parser` in the sunspot.yml. If the
option is not used then edismax is set as the default.

The reason for this is to help support those who need to interface older
Solr setups w/o having to monkey patch.